### PR TITLE
Fix memory corruption

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ static bool windowVisible = true;
 
 /// Create a custom platform which serves to wrap the WindowAdapter and return
 /// it when slint queries it internally. Register said platform with slint.
-void connectSlintToApp()
+slint::ComponentHandle<AppWindow> connectSlintToApp()
 {
 	auto platform = std::make_unique<KDSlintPlatform>();
 	auto windowAdapter = std::make_unique<LinuxWindowAdapter>();
@@ -38,12 +38,14 @@ void connectSlintToApp()
 		[&] { gui->set_counter(gui->get_counter() + 1); });
 
 	gui->show();
+
+	return std::move(gui);
 }
 
 auto main() -> int
 {
 	KDGui::GuiApplication app;
-	connectSlintToApp();
+	auto gui = connectSlintToApp();
 
 	while (windowVisible) {
 		app.processEvents();


### PR DESCRIPTION
Keep the KdWindow alive while processing events, otherwise

==53259== Invalid read of size 8
==53259==    at 0x49C6D8F: KDGui::LinuxXcbPlatformEventLoop::processXcbEvents() (linux_xcb_platform_event_loop.cpp:105)
==53259==    by 0x49C6BA0: KDGui::LinuxXcbPlatformEventLoop::waitForEvents(int) (linux_xcb_platform_event_loop.cpp:56)
==53259==    by 0x81038A6: KDFoundation::CoreApplication::processEvents(int) (core_application.cpp:146)
==53259==    by 0x14D4C8: main (main.cpp:49)
==53259==  Address 0xcef7360 is 0 bytes inside a block of size 88 free'd
==53259==    at 0x4846AFF: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==53259==    by 0x49CFC7C: KDGui::LinuxXcbPlatformWindow::~LinuxXcbPlatformWindow() (linux_xcb_platform_window.h:24)
==53259==    by 0x498F173: std::default_delete<KDGui::AbstractPlatformWindow>::operator()(KDGui::AbstractPlatformWindow*) const (unique_ptr.h:95)
==53259==    by 0x498AB9F: std::unique_ptr<KDGui::AbstractPlatformWindow, std::default_delete<KDGui::AbstractPlatformWindow> >::~unique_ptr() (unique_ptr.h:396)
==53259==    by 0x49841BF: KDGui::Window::~Window() (window.cpp:40)
==53259==    by 0x4984279: KDGui::Window::~Window() (window.cpp:40)
==53259==    by 0x190DAF: std::default_delete<KDGui::Window>::operator()(KDGui::Window*) const (unique_ptr.h:95)
==53259==    by 0x18FE71: std::unique_ptr<KDGui::Window, std::default_delete<KDGui::Window> >::~unique_ptr() (unique_ptr.h:396)
==53259==    by 0x1B15BD: LinuxWindowAdapter::~LinuxWindowAdapter() (window_adapter.h:6)
==53259==    by 0x1B15F9: LinuxWindowAdapter::~LinuxWindowAdapter() (window_adapter.h:6)
==53259==    by 0x15AE1F: slint::experimental::platform::WindowAdapter::initialize()::{lambda(void*)#1}::operator()(void*) const (slint_platform.h:56)
==53259==    by 0x15AE43: slint::experimental::platform::WindowAdapter::initialize()::{lambda(void*)#1}::_FUN(void*) (slint_platform.h:56)
==53259==    by 0x4E58A50: <slint_cpp::platform::CppWindowAdapter as core::ops::drop::Drop>::drop (platform.rs:39)
==53259==    by 0x4E588A3: core::ptr::drop_in_place<slint_cpp::platform::CppWindowAdapter> (mod.rs:490)
==53259==    by 0x64545BF: core::ptr::drop_in_place<dyn i_slint_core::window::WindowAdapter> (mod.rs:490)
==53259==    by 0x6455CCD: <alloc::rc::Rc<T> as core::ops::drop::Drop>::drop (rc.rs:1609)
==53259==    by 0x6454F3A: core::ptr::drop_in_place<alloc::rc::Rc<dyn i_slint_core::window::WindowAdapter>> (mod.rs:490)
==53259==    by 0x640E429: slint_windowrc_drop (window.rs:960)
==53259==    by 0x14FA85: slint::private_api::WindowAdapterRc::~WindowAdapterRc() (slint.h:107)
==53259==    by 0x1722F5: slint::Window::~Window() (slint.h:435)
==53259==    by 0x17231D: std::_Optional_payload_base<slint::Window>::_M_destroy() (optional:287)
==53259==    by 0x16DA2B: std::_Optional_payload_base<slint::Window>::_M_reset() (optional:318)
==53259==    by 0x1691BB: std::_Optional_payload<slint::Window, false, false, false>::~_Optional_payload() (optional:439)
==53259==    by 0x15A5E9: std::_Optional_base<slint::Window, false, false>::~_Optional_base() (optional:510)
==53259==    by 0x15A609: std::optional<slint::Window>::~optional() (optional:705)
==53259==    by 0x15AC94: AppWindow::~AppWindow() (appwindow.h:1173)
==53259==    by 0x165D07: vtable::Layout slint::private_api::drop_in_place<AppWindow>(vtable::VRefMut<slint::cbindgen_private::ComponentVTable>) (slint.h:319)
==53259==    by 0x168EF1: vtable::VRc<slint::cbindgen_private::ComponentVTable, AppWindow>::~VRc() (vtable.h:102)
==53259==    by 0x15A427: slint::ComponentHandle<AppWindow>::~ComponentHandle() (slint.h:355)
==53259==    by 0x14D380: connectSlintToApp() (main.cpp:41)
==53259==    by 0x14D4B2: main (main.cpp:46)